### PR TITLE
error logs seem to be full of '[object Event]' as the error message...

### DIFF
--- a/index.js
+++ b/index.js
@@ -113,6 +113,9 @@ class Loggerhead {
     try {
       var errorMessage = error.toString();
 
+      if (errorMessage == '[object Event]') {
+        errorMessage = error.message
+      }
       var stack = error.stack && error.stack
         .replace(/@https:\/\/[^\/]+\//g, '@')
         .split('\n').slice(0, 12).join('\n');


### PR DESCRIPTION
quick workaround to get real errors in those cases